### PR TITLE
Fix uninitialized constant issue for Artoo::Raspi::VERSION

### DIFF
--- a/lib/artoo-raspi.rb
+++ b/lib/artoo-raspi.rb
@@ -1,2 +1,2 @@
-require 'lib/artoo/adaptors/raspi'
-require 'lib/artoo-raspi/version'
+require 'artoo-raspi/version'
+require 'artoo/adaptors/raspi'

--- a/lib/artoo/adaptors/raspi.rb
+++ b/lib/artoo/adaptors/raspi.rb
@@ -1,3 +1,4 @@
+require 'artoo-raspi/version'
 require 'artoo/adaptors/adaptor'
 require 'artoo/adaptors/io'
 require 'pwm_pin'


### PR DESCRIPTION
This fixes the uninitialized constant issue (see issue #6 for details).