### PR TITLE
bugfix: clean up the raspi pins aswell when raspi adaptor is disconne…

### DIFF
--- a/lib/artoo/adaptors/raspi.rb
+++ b/lib/artoo/adaptors/raspi.rb
@@ -46,6 +46,8 @@ module Artoo
       def disconnect
         puts "Disconnecting all PWM pins..."
         release_all_pwm_pins
+        puts "Disconnecting all Raspi pins..."
+        close_all_raspi_pins
         super
       end
 
@@ -101,6 +103,10 @@ module Artoo
 
       def release_all_pwm_pins
         pwm_pins.each_value { |pwm_pin| pwm_pin.release }
+      end
+
+      def close_all_raspi_pins
+        pins.each_value { |pin| pin.close }
       end
 
       # Uses method missing to call device actions


### PR DESCRIPTION
Clean up the raspberryPi pins after program has shutdown. This is needed because the raspi adaptor cannot reuse the same pin if they have not been closed correctly. 
